### PR TITLE
Add harvester for atmosphere and ocean increment log files

### DIFF
--- a/src/score_hv/harvesters/inc_logs.py
+++ b/src/score_hv/harvesters/inc_logs.py
@@ -100,7 +100,7 @@ class LogIncHv(object):
     config: LogIncCfg = field(default_factory=LogIncCfg)
     
     def get_data(self):
-        """ Harvests ocean increment descriptive statistics.
+        """ Harvests increment descriptive statistics.
             Input file is a log text file.
         
             returns harvested_data, a list of HarvestData tuples

--- a/src/score_hv/harvesters/inc_logs.py
+++ b/src/score_hv/harvesters/inc_logs.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+
+""" Collection of methods to faciliate retrieval of increment
+    descriptive statistics from logs
+"""
+
+import os
+
+from collections import namedtuple
+from dataclasses import dataclass
+from dataclasses import field
+
+from score_hv.config_base import ConfigInterface
+
+HRVSTER_NAME = 'inc_logs'
+VALID_STATISTICS = ('mean', 'RMS')
+VALID_VARIABLES = ['pt_inc', 's_inc', 'u_inc', 'v_inc', 'SSH', 'Salinity',
+                   'Temperature', 'Speed of Currents', 'o3mr_inc', 'sphum_inc',
+                   'T_inc', 'delp_inc', 'delz_inc']
+
+HarvestedData = namedtuple('HarvestedData', ['logfile',
+                                             'statistic',
+                                             'variable',
+                                             'value', 
+                                             'units'])
+N_TUPLE_ENTRIES = 5                                             
+
+@dataclass
+class LogIncCfg(ConfigInterface):
+    """ Dataclass to hold and provide configuration information pertaining to
+        how the harvester should read increment log files
+    
+        Parameters:
+        -----------
+        config_data: dict - contains configuration data parsed from either an
+                            input yaml file or input dict
+        
+    """
+    config_data: dict = field(default_factory=dict)
+    
+    def __post_init__(self):
+        self.set_config()
+    
+    def set_config(self):
+        """ function to set configuration variables from given dictionary
+        """ 
+        try:
+            self.harvest_filename = self.config_data.get('filename')
+        except Exception as err:
+            msg = '%s key missing' % key
+            raise KeyError(msg) from err
+        
+        self.set_stats()
+        self.set_variables()
+    
+    def set_variables(self):
+        """
+        set the variables specified by the config dict
+        """
+        try:
+            self.variables = self.config_data.get('variable')
+            for var in self.variables:
+                if var not in VALID_VARIABLES:
+                    msg = f'Invalid variable, must be one of \'{VALID_VARIABLES}\''
+                    raise KeyError(msg)
+        except Exception as err:
+            msg = f'\'variables\' key missing, must be one of ' \
+                f'({VALID_VARIABLES}) - err: {err}'
+            raise KeyError(msg) from err
+
+    def set_stats(self):
+        """
+        set the statistics specified by the config dict
+        """
+        try:
+            self.stats = self.config_data.get('statistic')
+            for stat in self.stats:
+                if stat not in VALID_STATISTICS:
+                    msg = f'Invalid statistic, must be one of \'{VALID_STATISTICS}\''
+                    raise KeyError(msg)
+        except Exception as err:
+            msg = f'\'statistics\' key missing, must be one of ' \
+                f'({VALID_STATISTICS}) - err: {err}'
+            raise KeyError(msg) from err
+    
+    def get_stats(self):
+        ''' return list of all stat types based on harvest_config '''
+        return self.stats
+        
+    def get_variables(self):
+        ''' return list of all variable types based on harvest_config'''
+        return self.variables
+        
+@dataclass
+class LogIncHv(object):
+    """ Harvester dataclass used to parse increment descriptive
+        statistics stored in log files
+    
+        Parameters:
+        -----------
+        config: IncCfg object containing information used to determine
+                which variable to parse the log file
+        Methods:
+        --------
+        get_data: parse descriptive statistics from log files based on input
+                  config file
+    
+                  returns a list of tuples containing specific data
+    """
+    config: LogIncCfg = field(default_factory=LogIncCfg)
+    
+    def get_data(self):
+        """ Harvests ocean increment descriptive statistics.
+            Input file is a log text file.
+        
+            returns harvested_data, a list of HarvestData tuples
+        """
+        harvested_data = []        
+        # read in file
+        # find section for statistics
+        # read values
+        
+        with open(self.config.harvest_filename) as log_file:
+            lines = log_file.readlines()
+        
+        for i, line in enumerate(lines):
+            """ The outer most loop iterates through each line
+            """                
+            for j, variable in enumerate(self.config.get_variables()):
+                """ The first nested loop iterates through each requested variable
+                """
+                for k, statistic in enumerate(self.config.get_stats()):
+                    """ The second nested loop iterates through each requested statistic
+                    """
+                    if line.split(',')[1][1:] == variable:
+                        """ harvest data
+                        """
+                        if statistic == VALID_STATISTICS[0]:
+                            """ harvest mean
+                            """ 
+                            harvest_tuple = HarvestedData(
+                                self.config.harvest_filename,
+                                statistic,
+                                variable,
+                                float(line.split(',')[-2]), # value
+                                'unspecified', # units
+                                )
+                        elif statistic == VALID_STATISTICS[1]:
+                            """ harvest RMS
+                            """
+                            harvest_tuple = HarvestedData(
+                                self.config.harvest_filename,
+                                statistic,
+                                variable,
+                                float(line.split(',')[-1]), # value
+                                'unspecified', # units
+                                )
+                        else:
+                            harvest_tuple = ()
+                        
+                        if len(harvest_tuple) == N_TUPLE_ENTRIES:
+                            harvested_data.append(harvest_tuple)
+    
+        return harvested_data

--- a/src/score_hv/harvesters/inc_logs.py
+++ b/src/score_hv/harvesters/inc_logs.py
@@ -12,7 +12,7 @@ from dataclasses import field
 
 from score_hv.config_base import ConfigInterface
 
-HRVSTER_NAME = 'inc_logs'
+HARVESTER_NAME = 'inc_logs'
 VALID_STATISTICS = ('mean', 'RMS')
 VALID_VARIABLES = ['pt_inc', 's_inc', 'u_inc', 'v_inc', 'SSH', 'Salinity',
                    'Temperature', 'Speed of Currents', 'o3mr_inc', 'sphum_inc',
@@ -44,12 +44,7 @@ class LogIncCfg(ConfigInterface):
     def set_config(self):
         """ function to set configuration variables from given dictionary
         """ 
-        try:
-            self.harvest_filename = self.config_data.get('filename')
-        except Exception as err:
-            msg = '%s key missing' % key
-            raise KeyError(msg) from err
-        
+        self.harvest_filename = self.config_data.get('filename')
         self.set_stats()
         self.set_variables()
     
@@ -57,31 +52,26 @@ class LogIncCfg(ConfigInterface):
         """
         set the variables specified by the config dict
         """
-        try:
-            self.variables = self.config_data.get('variable')
-            for var in self.variables:
-                if var not in VALID_VARIABLES:
-                    msg = f'Invalid variable, must be one of \'{VALID_VARIABLES}\''
-                    raise KeyError(msg)
-        except Exception as err:
-            msg = f'\'variables\' key missing, must be one of ' \
-                f'({VALID_VARIABLES}) - err: {err}'
-            raise KeyError(msg) from err
+        
+        self.variables = self.config_data.get('variable')
+        for var in self.variables:
+            if var not in VALID_VARIABLES:
+                msg = ("'%s' is not a supported variable to harvest from the incrememt log files. "
+                       "Please reconfigure the input dictionary using only the "
+                       "following variables: %r" % (var, VALID_VARIABLES))
+                raise KeyError(msg)
 
     def set_stats(self):
         """
         set the statistics specified by the config dict
         """
-        try:
-            self.stats = self.config_data.get('statistic')
-            for stat in self.stats:
-                if stat not in VALID_STATISTICS:
-                    msg = f'Invalid statistic, must be one of \'{VALID_STATISTICS}\''
-                    raise KeyError(msg)
-        except Exception as err:
-            msg = f'\'statistics\' key missing, must be one of ' \
-                f'({VALID_STATISTICS}) - err: {err}'
-            raise KeyError(msg) from err
+        self.stats = self.config_data.get('statistic')
+        for stat in self.stats:
+            if stat not in VALID_STATISTICS:
+                msg = ("'%s' is not a supported statistic to harvest from the incrememt log files. "
+                       "Please reconfigure the input dictionary using only the "
+                       "following statistics: %r" % (stat, VALID_STATISTICS))
+                raise KeyError(msg)
     
     def get_stats(self):
         ''' return list of all stat types based on harvest_config '''

--- a/src/score_hv/harvesters/innov_netcdf.py
+++ b/src/score_hv/harvesters/innov_netcdf.py
@@ -33,7 +33,7 @@ PLEV_PRESURE_UNIT = 'mb'
 MIN_LONG = -180
 MAX_LONG = 180
 
-HRVSTR_NAME = 'innov_stats_'
+HARVESTER_NAME = 'innov_stats_'
 
 @dataclass
 class Region:
@@ -374,7 +374,7 @@ class InnovStatsHv:
                     time_valid = metric.cycletime + timedelta(hours=6)
 
                     for idx in range(len(nc_vardata)):
-                        name = HRVSTR_NAME + metric.name + '_' + stat
+                        name = HARVESTER_NAME + metric.name + '_' + stat
                         item = HarvestedData(
                             name,
                             time_valid,

--- a/src/score_hv/hv_registry.py
+++ b/src/score_hv/hv_registry.py
@@ -15,7 +15,6 @@ PANDAS_DATAFRAME = 'pandas_dataframe'
 
 INNOV_NETCDF = 'innov_stats_netcdf'
 OBS_INFO_LOG = 'obs_info_log'
-
 INC_LOGS = 'inc_logs'
 
 Harvester = namedtuple('Harvester', ('name', 'config_handler', 'data_parser'),)

--- a/src/score_hv/hv_registry.py
+++ b/src/score_hv/hv_registry.py
@@ -8,39 +8,32 @@ Collection of methods to facilitate file/object retrieval
 from collections import namedtuple
 from score_hv.harvesters.innov_netcdf import InnovStatsCfg, InnovStatsHv
 from score_hv.harvesters.obs_log import ObsInfoCfg, ObsInfoHv
-from score_hv.harvesters.inc_logs import AtmIncCfg
-from score_hv.harvesters.inc_logs import AtmIncHv
+from score_hv.harvesters.inc_logs import LogIncCfg, LogIncHv
 
 NAMED_TUPLES_LIST = 'tuples_list'
 PANDAS_DATAFRAME = 'pandas_dataframe'
 
 INNOV_NETCDF = 'innov_stats_netcdf'
 OBS_INFO_LOG = 'obs_info_log'
-ATM_INC_LOGS = 'atm_inc_logs'
 
-Harvester = namedtuple(
-    'Harvester',
-    [
-        'name',
-        'config_handler',
-        'data_parser'
-    ],
-)
+INC_LOGS = 'inc_logs'
 
-harvester_registry = {
-    'innov_stats_netcdf': Harvester(
-        'innovation statistics for temperature, spechumid, uvwind, and salinity (netcdf)',
-        InnovStatsCfg,
-        InnovStatsHv
-    ),
-    'obs_info_log': Harvester(
-        'observation information for pressure, specific humidity, temperature, height, wind components, '
-        'precipitable h2o, and relative humidity (log)',
-         ObsInfoCfg,
-         ObsInfoHv
-    ),
-    ATM_INC_LOGS: Harvester('atmosphere increment descriptive statistics from '
-                            'log files',
-                             AtmIncCfg,
-                             AtmIncHv)
-}
+Harvester = namedtuple('Harvester', ('name', 'config_handler', 'data_parser'),)
+
+harvester_registry = {INNOV_NETCDF: Harvester(
+                         'innovation statistics for temperature, spechumid, '
+                          'uvwind, and salinity (netcdf)',
+                          InnovStatsCfg,
+                          InnovStatsHv),
+                      OBS_INFO_LOG: Harvester(
+                          'observation information for pressure, specific '
+                          'humidity, temperature, height, wind components, '
+                          'precipitable h2o, and relative humidity (log)',
+                          ObsInfoCfg,
+                          ObsInfoHv),
+                      INC_LOGS: Harvester(
+                          'increment descriptive statistics from '
+                          'log files',
+                          LogIncCfg,
+                          LogIncHv)
+                   }

--- a/tests/data/calc_atm_inc.out
+++ b/tests/data/calc_atm_inc.out
@@ -1,0 +1,7 @@
+Mean and RMS of, o3mr_inc,  -0.120E-07,   0.199E-06
+Mean and RMS of, sphum_inc,   0.296E-04,   0.473E-03
+Mean and RMS of, T_inc,   0.378E-02,   0.604E+00
+Mean and RMS of, u_inc,   0.475E-01,   0.136E+01
+Mean and RMS of, v_inc,  -0.588E-02,   0.135E+01
+Mean and RMS of, delp_inc,   0.313E-01,   0.223E+01
+Mean and RMS of, delz_inc,  -0.319E-01,   0.407E+00

--- a/tests/data/calc_ocn_inc.out
+++ b/tests/data/calc_ocn_inc.out
@@ -1,0 +1,8 @@
+Mean and RMS of, pt_inc,  -0.657E-02,   0.944E-01
+Mean and RMS of, s_inc,   0.108E-02,   0.330E-01
+Mean and RMS of, u_inc,   0.300E-03,   0.304E-01
+Mean and RMS of, v_inc,   0.155E-03,   0.283E-01
+Mean and RMS of, SSH,   0.667E-01,   0.664E+00
+Mean and RMS of, Salinity,   0.348E+02,   0.348E+02
+Mean and RMS of, Temperature,   0.112E+02,   0.150E+02
+Mean and RMS of, Speed of Currents,   0.928E-01,   0.154E+00

--- a/tests/test_harvester_atm_inc_logs.py
+++ b/tests/test_harvester_atm_inc_logs.py
@@ -13,7 +13,6 @@ from score_hv.harvester_base import harvest
 from score_hv.yaml_utils import YamlLoader
 
 PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
-#LOG_HARVESTER_CONFIG__VALID = 'log_harvestor_config__valid.yaml'
 LOG_HARVESTER_ATM__VALID = 'calc_atm_inc.out'
 
 DATA_DIR = 'data'
@@ -38,7 +37,6 @@ def test_ozone_mixing_ratio_inc(varname='o3mr_inc'):
     for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
         if variable == varname:
             variable_rank = i
-    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     
     n_stats = len(VALID_CONFIG_DICT['statistic'])
@@ -83,11 +81,10 @@ def test_delta_pressure_inc():
 def test_delta_z_inc():
     harvest_data('delz_inc', -0.319E-01, 0.407E+00)
 
-def harvest_data(varname, expected_ans_0, expected_ans_1):
+def harvest_data(varname, expected_ans_mean, expected_ans_rms):
     for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
         if variable == varname:
             variable_rank = i
-    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     
     n_stats = len(VALID_CONFIG_DICT['statistic'])
@@ -111,9 +108,9 @@ def harvest_data(varname, expected_ans_0, expected_ans_1):
         assert valid_statistic == 'mean' or valid_statistic == 'RMS'
         
         if valid_statistic == 'mean':
-            assert valid_tuple_subset[i][3] == expected_ans_0
+            assert valid_tuple_subset[i][3] == expected_ans_mean
         elif valid_statistic == 'RMS': # RMS
-            assert valid_tuple_subset[i][3] == expected_ans_1
+            assert valid_tuple_subset[i][3] == expected_ans_rms
 
 def run_tests():
     """ Run the test suite

--- a/tests/test_harvester_atm_inc_logs.py
+++ b/tests/test_harvester_atm_inc_logs.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+
+""" Unit tests for atmosphere increment descriptive statistics harvester
+"""
+
+import pathlib
+import os
+
+import numpy as np
+
+from score_hv import hv_registry
+from score_hv.harvester_base import harvest
+from score_hv.yaml_utils import YamlLoader
+
+PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
+#LOG_HARVESTER_CONFIG__VALID = 'log_harvestor_config__valid.yaml'
+LOG_HARVESTER_ATM__VALID = 'calc_atm_inc.out'
+
+DATA_DIR = 'data'
+CONFIGS_DIR = 'configs'
+
+TEST_DATA_PATH = os.path.join(PYTEST_CALLING_DIR, DATA_DIR)
+FILE_PATH_ATM_INC_LOGS = os.path.join(TEST_DATA_PATH,
+                                      LOG_HARVESTER_ATM__VALID)
+                 
+VALID_CONFIG_DICT = {'harvester_name': hv_registry.INC_LOGS,
+                     'filename' : FILE_PATH_ATM_INC_LOGS,
+                     'statistic': ['mean', 'RMS'],
+                     'variable': ['o3mr_inc', 'sphum_inc', 'T_inc', 'u_inc', 'v_inc',
+                                  'delp_inc', 'delz_inc']}
+
+def test_inc_harvester_get_data():
+    data1 = harvest(VALID_CONFIG_DICT)  
+    assert type(data1) is list
+    assert len(data1) > 0
+        
+def test_ozone_mixing_ratio_inc(varname='o3mr_inc'):
+    for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
+        if variable == varname:
+            variable_rank = i
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    
+    n_stats = len(VALID_CONFIG_DICT['statistic'])
+    
+    valid_idxs_in_tuple = np.arange(n_stats) + variable_rank * n_stats
+    
+    stats_harvested = list()
+    pt_tuple_subset = list()
+    data1 = harvest(VALID_CONFIG_DICT)
+    for i, harvested_data_tuple in enumerate(data1):
+        if np.isin(i, valid_idxs_in_tuple): # pt_inc data
+            assert harvested_data_tuple[1] in VALID_CONFIG_DICT['statistic']
+            stats_harvested.append(harvested_data_tuple[1])
+            assert harvested_data_tuple[2] == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            pt_tuple_subset.append(harvested_data_tuple)
+    
+    for i, valid_statistic in enumerate(VALID_CONFIG_DICT['statistic']):
+        assert valid_statistic == stats_harvested[i]
+        assert valid_statistic == 'mean' or valid_statistic == 'RMS'
+        
+        if valid_statistic == 'mean':
+            assert pt_tuple_subset[i][3] == -0.120E-07
+        elif valid_statistic == 'RMS': # RMS
+            assert pt_tuple_subset[i][3] == 0.199E-06
+                        
+def test_specific_humidity_inc():
+    harvest_data('sphum_inc', 0.296E-04, 0.473E-03)
+    
+def test_temperature_inc():
+    harvest_data('T_inc', 0.378E-02, 0.604E+00)
+    
+def test_westerly_wind_component_inc():
+    harvest_data('u_inc', 0.475E-01, 0.136E+01)
+    
+def test_southerly_wind_component_inc():
+    harvest_data('v_inc', -0.588E-02, 0.135E+01)
+    
+def test_delta_pressure_inc():
+    harvest_data('delp_inc', 0.313E-01, 0.223E+01)
+    
+def test_delta_z_inc():
+    harvest_data('delz_inc', -0.319E-01, 0.407E+00)
+
+def harvest_data(varname, expected_ans_0, expected_ans_1):
+    for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
+        if variable == varname:
+            variable_rank = i
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    
+    n_stats = len(VALID_CONFIG_DICT['statistic'])
+    
+    valid_idxs_in_tuple = np.arange(n_stats) + variable_rank * n_stats
+    
+    stats_harvested = list()
+    valid_tuple_subset = list()
+    data1 = harvest(VALID_CONFIG_DICT)
+    for i, harvested_data_tuple in enumerate(data1):
+        
+        if np.isin(i, valid_idxs_in_tuple):
+            assert harvested_data_tuple[1] in VALID_CONFIG_DICT['statistic']
+            stats_harvested.append(harvested_data_tuple[1])
+            assert harvested_data_tuple[2] == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            valid_tuple_subset.append(harvested_data_tuple)
+    
+    for i, valid_statistic in enumerate(VALID_CONFIG_DICT['statistic']):
+        assert valid_statistic == stats_harvested[i]
+        assert valid_statistic == 'mean' or valid_statistic == 'RMS'
+        
+        if valid_statistic == 'mean':
+            assert valid_tuple_subset[i][3] == expected_ans_0
+        elif valid_statistic == 'RMS': # RMS
+            assert valid_tuple_subset[i][3] == expected_ans_1
+
+def run_tests():
+    """ Run the test suite
+    """
+    test_inc_harvester_get_data()
+    test_ozone_mixing_ratio_inc()
+    test_specific_humidity_inc()
+    test_temperature_inc()
+    test_westerly_wind_component_inc()
+    test_southerly_wind_component_inc()
+    test_delta_pressure_inc()
+    test_delta_z_inc()
+    
+def main():
+    run_tests()
+    
+if __name__=='__main__':
+    import ipdb
+    main()

--- a/tests/test_harvester_ocn_inc_logs.py
+++ b/tests/test_harvester_ocn_inc_logs.py
@@ -13,7 +13,6 @@ from score_hv.harvester_base import harvest
 from score_hv.yaml_utils import YamlLoader
 
 PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
-#LOG_HARVESTER_CONFIG__VALID = 'log_harvestor_config__valid.yaml'
 LOG_HARVESTER_OCN__VALID = 'calc_ocn_inc.out'
 
 DATA_DIR = 'data'
@@ -38,7 +37,6 @@ def test_pt_inc(varname='pt_inc'):
     for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
         if variable == varname:
             variable_rank = i
-    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     
     n_stats = len(VALID_CONFIG_DICT['statistic'])
@@ -86,11 +84,10 @@ def test_temperature():
 def test_speed_of_currents():
     harvest_data('Speed of Currents', 0.928E-01, 0.154E+00)
 
-def harvest_data(varname, expected_ans_0, expected_ans_1):
+def harvest_data(varname, expected_ans_mean, expected_ans_rms):
     for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
         if variable == varname:
             variable_rank = i
-    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
     
     n_stats = len(VALID_CONFIG_DICT['statistic'])
@@ -114,9 +111,9 @@ def harvest_data(varname, expected_ans_0, expected_ans_1):
         assert valid_statistic == 'mean' or valid_statistic == 'RMS'
         
         if valid_statistic == 'mean':
-            assert valid_tuple_subset[i][3] == expected_ans_0
+            assert valid_tuple_subset[i][3] == expected_ans_mean
         elif valid_statistic == 'RMS': # RMS
-            assert valid_tuple_subset[i][3] == expected_ans_1
+            assert valid_tuple_subset[i][3] == expected_ans_rms
 
 def run_tests():
     """ Run the test suite

--- a/tests/test_harvester_ocn_inc_logs.py
+++ b/tests/test_harvester_ocn_inc_logs.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+""" Unit tests for ocean increment descriptive statistics harvester
+"""
+
+import pathlib
+import os
+
+import numpy as np
+
+from score_hv import hv_registry
+from score_hv.harvester_base import harvest
+from score_hv.yaml_utils import YamlLoader
+
+PYTEST_CALLING_DIR = pathlib.Path(__file__).parent.resolve()
+#LOG_HARVESTER_CONFIG__VALID = 'log_harvestor_config__valid.yaml'
+LOG_HARVESTER_OCN__VALID = 'calc_ocn_inc.out'
+
+DATA_DIR = 'data'
+CONFIGS_DIR = 'configs'
+
+TEST_DATA_PATH = os.path.join(PYTEST_CALLING_DIR, DATA_DIR)
+FILE_PATH_OCN_INC_LOGS = os.path.join(TEST_DATA_PATH,
+                                      LOG_HARVESTER_OCN__VALID)
+                 
+VALID_CONFIG_DICT = {'harvester_name': hv_registry.INC_LOGS,
+                     'filename' : FILE_PATH_OCN_INC_LOGS,
+                     'statistic': ['mean', 'RMS'],
+                     'variable': ['pt_inc', 's_inc', 'u_inc', 'v_inc', 'SSH',
+                                  'Salinity', 'Temperature', 'Speed of Currents']}
+
+def test_inc_harvester_get_data():
+    data1 = harvest(VALID_CONFIG_DICT)  
+    assert type(data1) is list
+    assert len(data1) > 0
+        
+def test_pt_inc(varname='pt_inc'):
+    for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
+        if variable == varname:
+            variable_rank = i
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    
+    n_stats = len(VALID_CONFIG_DICT['statistic'])
+    
+    valid_idxs_in_tuple = np.arange(n_stats) + variable_rank * n_stats
+    
+    stats_harvested = list()
+    pt_tuple_subset = list()
+    data1 = harvest(VALID_CONFIG_DICT)
+    for i, harvested_data_tuple in enumerate(data1):
+        if np.isin(i, valid_idxs_in_tuple): # pt_inc data
+            assert harvested_data_tuple[1] in VALID_CONFIG_DICT['statistic']
+            stats_harvested.append(harvested_data_tuple[1])
+            assert harvested_data_tuple[2] == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            pt_tuple_subset.append(harvested_data_tuple)
+    
+    for i, valid_statistic in enumerate(VALID_CONFIG_DICT['statistic']):
+        assert valid_statistic == stats_harvested[i]
+        assert valid_statistic == 'mean' or valid_statistic == 'RMS'
+        
+        if valid_statistic == 'mean':
+            assert pt_tuple_subset[i][3] == -0.657E-02
+        elif valid_statistic == 'RMS': # RMS
+            assert pt_tuple_subset[i][3] == 0.944E-01
+                        
+def test_s_inc():
+    harvest_data('s_inc', 0.108E-02, 0.330E-01)
+    
+def test_u_inc():
+    harvest_data('u_inc', 0.300E-03, 0.304E-01)
+    
+def test_v_inc():
+    harvest_data('v_inc', 0.155E-03, 0.283E-01)
+    
+def test_ssh():
+    harvest_data('SSH', 0.667E-01, 0.664E+00)
+    
+def test_salinity():
+    harvest_data('Salinity', 0.348E+02, 0.348E+02)
+    
+def test_temperature():
+    harvest_data('Temperature', 0.112E+02, 0.150E+02)
+    
+def test_speed_of_currents():
+    harvest_data('Speed of Currents', 0.928E-01, 0.154E+00)
+
+def harvest_data(varname, expected_ans_0, expected_ans_1):
+    for i, variable in enumerate(VALID_CONFIG_DICT['variable']):
+        if variable == varname:
+            variable_rank = i
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    assert VALID_CONFIG_DICT['variable'][variable_rank]==varname
+    
+    n_stats = len(VALID_CONFIG_DICT['statistic'])
+    
+    valid_idxs_in_tuple = np.arange(n_stats) + variable_rank * n_stats
+    
+    stats_harvested = list()
+    valid_tuple_subset = list()
+    data1 = harvest(VALID_CONFIG_DICT)
+    for i, harvested_data_tuple in enumerate(data1):
+        
+        if np.isin(i, valid_idxs_in_tuple):
+            assert harvested_data_tuple[1] in VALID_CONFIG_DICT['statistic']
+            stats_harvested.append(harvested_data_tuple[1])
+            assert harvested_data_tuple[2] == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            valid_tuple_subset.append(harvested_data_tuple)
+    
+    for i, valid_statistic in enumerate(VALID_CONFIG_DICT['statistic']):
+        assert valid_statistic == stats_harvested[i]
+        assert valid_statistic == 'mean' or valid_statistic == 'RMS'
+        
+        if valid_statistic == 'mean':
+            assert valid_tuple_subset[i][3] == expected_ans_0
+        elif valid_statistic == 'RMS': # RMS
+            assert valid_tuple_subset[i][3] == expected_ans_1
+
+def run_tests():
+    """ Run the test suite
+    """
+    test_inc_harvester_get_data()
+    test_pt_inc()
+    test_s_inc()
+    test_u_inc()
+    test_v_inc()
+    test_ssh()
+    test_salinity()
+    test_temperature()
+    test_speed_of_currents()
+    
+def main():
+    run_tests()
+    
+if __name__=='__main__':
+    import ipdb
+    main()


### PR DESCRIPTION
Implements harvester and corresponding unit tests that parses and extracts descriptive statistics from new sample calc_atm_inc.out and calc_ocn_inc.out log files. Changes include:

- new sample tests/data for unit tests (calc_atm_inc.out and calc_ocn_inc.out)
- unit tests for harvesters (test_harvester_atm_inc_logs.py and test_harvester_ocn_inc_logs.py)
- new entry in hv_registry.harvester_registry dictionary
- new harvester (classes and methods in harvesters/inc_logs.py)

All existing and newly implemented unit tests are passing.

closes [issue #18 ](https://github.com/NOAA-PSL/score-hv/issues/18)