### PR TITLE
Patch increment harvester so that it returns unique variable names fo…

### DIFF
--- a/src/score_hv/harvesters/inc_logs.py
+++ b/src/score_hv/harvesters/inc_logs.py
@@ -121,12 +121,27 @@ class LogIncHv(object):
             for j, variable in enumerate(self.config.get_variables()):
                 """ The first nested loop iterates through each requested variable
                 """
+                if variable == 'u_inc' or variable == 'v_inc':
+                    """ Because both atmosphere and ocean wind speed
+                        increments (u_inc and v_inc) are named the 
+                        same, must append these variable names based on 
+                        if they are relevant for the atmosphere 
+                        ("_atm") or ocean ("_ocn") metrics
+                    """
+                    if self.config.harvest_filename.split('_')[-2] == 'atm':
+                        varname_out = variable + "_atm"
+                    elif self.config.harvest_filename.split('_')[-2] == 'ocn':
+                        varname_out = variable + "_ocn"
+                
+                else:
+                    varname_out = variable
+                        
                 for k, statistic in enumerate(self.config.get_stats()):
                     """ The second nested loop iterates through each requested statistic
                     """
                     if line.split(',')[1][1:] == variable:
                         """ harvest data
-                        """
+                        """        
                         if statistic == VALID_STATISTICS[0]:
                             """ harvest mean
                             """ 
@@ -134,7 +149,7 @@ class LogIncHv(object):
                                 self.config.harvest_filename,
                                 self.config.cycletime,
                                 statistic,
-                                variable,
+                                varname_out,
                                 float(line.split(',')[-2]), # value
                                 'unspecified', # units
                                 )
@@ -145,7 +160,7 @@ class LogIncHv(object):
                                 self.config.harvest_filename,
                                 self.config.cycletime,
                                 statistic,
-                                variable,
+                                varname_out,
                                 float(line.split(',')[-1]), # value
                                 'unspecified', # units
                                 )

--- a/tests/test_harvester_atm_inc_logs.py
+++ b/tests/test_harvester_atm_inc_logs.py
@@ -101,7 +101,20 @@ def harvest_data(varname, expected_ans_mean, expected_ans_rms):
         if np.isin(i, valid_idxs_in_tuple):
             assert harvested_data_tuple.statistic in VALID_CONFIG_DICT['statistic']
             stats_harvested.append(harvested_data_tuple.statistic)
-            assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            if harvested_data_tuple.variable == 'u_inc_atm' or harvested_data_tuple.variable == 'v_inc_atm':
+                """ This is a special case for wind velocity component 
+                    increments, because these metrics share common names 
+                    across atmosphere and ocean components. Because there is 
+                    only one increment harvester, the harvester appends "_atm" 
+                    or "_ocn" to these variable names so that these metrics 
+                    could later be distinguished by atmosphere or ocean in the
+                    downstream database.
+                """
+                assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank] + "_atm"
+            
+            else:
+                assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank]
             
             valid_tuple_subset.append(harvested_data_tuple)
     

--- a/tests/test_harvester_ocn_inc_logs.py
+++ b/tests/test_harvester_ocn_inc_logs.py
@@ -104,7 +104,20 @@ def harvest_data(varname, expected_ans_mean, expected_ans_rms):
         if np.isin(i, valid_idxs_in_tuple):
             assert harvested_data_tuple.statistic in VALID_CONFIG_DICT['statistic']
             stats_harvested.append(harvested_data_tuple.statistic)
-            assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank]
+            
+            if harvested_data_tuple.variable == 'u_inc_ocn' or harvested_data_tuple.variable == 'v_inc_ocn':
+                """ This is a special case for wind velocity component 
+                    increments, because these metrics share common names 
+                    across atmosphere and ocean components. Because there is 
+                    only one increment harvester, the harvester appends "_atm" 
+                    or "_ocn" to these variable names so that these metrics 
+                    could later be distinguished by atmosphere or ocean in the
+                    downstream database.
+                """
+                assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank] + "_ocn"
+            
+            else:
+                assert harvested_data_tuple.variable == VALID_CONFIG_DICT['variable'][variable_rank]
             
             valid_tuple_subset.append(harvested_data_tuple)
     


### PR DESCRIPTION
…r atmosphere and ocean wind velocity component increments (appending "_atm" or "_ocn" to u_inc and v_inc)

This patch resolves a problem with the increment harvester. Previously, wind velocity component increments (u_inc and v_inc) for both the atmosphere and ocean log files were being harvested and stored as the same metric. This approach makes it difficult to distinguish which metrics pertain to the atmosphere versus the ocean.

This PR brings in a patch that appends "_atm" or "_ocn" to the output harvested variable name for the wind velocity component increments, so that these metrics would be stored in the downstream database as u_inc_atm or v_inc_atm and u_inc_ocn or v_inc_ocn for atmosphere increments and ocean increments, respectively.

Modifications include the patch applied to the harvester itself and updated unit tests to account for "_atm" or "_ocn" concatenated to u_inc and v_inc.