### PR TITLE
Changed daily precip median time from cftime datetime to datetime dat…

### DIFF
--- a/src/score_hv/harvesters/global_bucket_precip_ave.py
+++ b/src/score_hv/harvesters/global_bucket_precip_ave.py
@@ -6,7 +6,7 @@ import sys
 import numpy as np
 from netCDF4 import MFDataset
 import xarray as xr
-import datetime
+from datetime import datetime as dt
 import cftime
 from collections import namedtuple
 from dataclasses import dataclass
@@ -149,13 +149,12 @@ class GlobalBucketPrecipRateHv(object):
                 """
                 if statistic == 'mean':
                     mean_precip = np.ma.mean(np.ma.masked_invalid(precip_data.values))
-                    
                     harvested_data.append(HarvestedData(
-                                                 self.config.harvest_filenames,
-                                                 statistic, 
-                                                 variable,
-                                                 np.float32(mean_precip),
-                                                 units,
-                                                 median_cftime,
-                                                 longname))
+                                             self.config.harvest_filenames,
+                                             statistic, 
+                                             variable,
+                                             np.float32(mean_precip),
+                                             units,
+                                             dt.fromisoformat(median_cftime.isoformat()),
+                                             longname))
         return harvested_data


### PR DESCRIPTION
…etime, as needed for storing in the SQL database

Addresses issue #32.

This is just a simple fix that converts the cftime datetime to a datetime datetime using the isoformat() method.

All tests pass and this fix enables score-monitoring to call the harvester and store data into the SQL database.